### PR TITLE
do not log at warn level

### DIFF
--- a/src/main/java/io/dashbase/AbstractDashbaseEventBuilder.java
+++ b/src/main/java/io/dashbase/AbstractDashbaseEventBuilder.java
@@ -112,7 +112,7 @@ public abstract class AbstractDashbaseEventBuilder<T, B extends AbstractDashbase
     if (name != null && val != null) {
       map.put(name, val);
     } else {
-      LOGGER.warn("name {} and value {} cannot be null", name, val, new IllegalArgumentException());
+      LOGGER.debug("name {} and value {} cannot be null", name, val, new IllegalArgumentException());
     }
   }
 }


### PR DESCRIPTION
warg is dumping tons of logs because FilebeatParser is trying to add null values.
```
name type and value null cannot be null ! java.lang.IllegalArgumentException
```

changing the log level from warn to debug to not explode the log file.